### PR TITLE
Don't begone my current branch

### DIFF
--- a/bin/git-begone
+++ b/bin/git-begone
@@ -26,7 +26,7 @@ local-git-branches() {
 }
 
 find-gone-branches() {
-  rg -v develop | rg -v master | rg "\[.*: gone\]" | sed -E -e 's/^[ ]+//' | awk '{ print $1 }'
+  rg -v '^\*' | rg -v develop | rg -v master | rg "\[.*: gone\]" | sed -E -e 's/^[ ]+//' | awk '{ print $1 }'
 }
 
 maybe-delete() {


### PR DESCRIPTION
In case you find this useful :)

When running `git-begone` on a non-master branch you may see:

```
* is GONE on origin, run git begone -f to delete
```

This tells git-begone to skip whatever the current branch is.